### PR TITLE
Building with `CustomCode-Analyzer` by default

### DIFF
--- a/odc-externallogic-template/ODCExternalLogic.Library/ODCExternalLogic.Library.csproj
+++ b/odc-externallogic-template/ODCExternalLogic.Library/ODCExternalLogic.Library.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="CustomCode.Analyzer" Version="0.2.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="OutSystems.ExternalLibraries.SDK" Version="1.5.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Trying to promote the use of [`CustomCode-Analyzer`](https://github.com/jonathanalgar/CustomCode-Analyzer/tree/main) 😊
Would it be interesting for users of the template to have this functionality by default?